### PR TITLE
Missing exposures for Evergreen migrations

### DIFF
--- a/src/Authentication.elm
+++ b/src/Authentication.elm
@@ -1,5 +1,6 @@
 module Authentication exposing
     ( AuthenticationDict
+    , UserData
     , encryptForTransit
     , insert
     , users

--- a/src/Credentials.elm
+++ b/src/Credentials.elm
@@ -1,4 +1,4 @@
-module Credentials exposing (Credentials, Error, check, generator, hashPw, pregen)
+module Credentials exposing (Credentials(..), Error, check, generator, hashPw, pregen)
 
 import Bytes exposing (Bytes, Endianness(..))
 import Bytes.Encode as Encode exposing (encode, string)


### PR DESCRIPTION
Hey Jim

So I think we've run into this issue before.

In short, the sneaky switch that `lamdera check` does to make sure our snapshot types are identical to our real `Types.elm` is causing some confusion. 

The trick, as always, is super pedantic reading of the pretty-much-always-right Elm error messages!

```
-- NAMING ERROR ----------------------------------- src/Evergreen/Migrate/V2.elm

I cannot find a `Authentication.UserData` type:

109| userDataIdentity : Evergreen.V1.Authentication.UserData -> Authentication.UserData
                                                                ^^^^^^^^^^^^^^^^^^^^^^^
The `Authentication` module does not expose a `UserData` type. These names seem
close though:

    Evergreen.V1.Authentication.UserData
    Authentication.AuthenticationDict
    Credentials.Error
    Evergreen.V1.Authentication.Username

Hint: Read <https://elm-lang.org/0.19.1/imports> to see how `import`
declarations work in Elm.
```

The trick here is that `Authentication.UserData` literally means the `src/Authentication.elm:UserData`. I know this is confusing as our migrations are written in terms of `Evergreen.V2.Authentication.UserData` – so this is the sneaky switch I'm referring to.

If you look at the commit here, you'll see that type was not exposed in your normal project code, which means in production the Evergreen migration would not be able to reach it to decode into your current model!

The same goes for the next error:

```
-- NAMING ERROR ----------------------------------- src/Evergreen/Migrate/V2.elm

I cannot find a `Credentials.V1` variant:

106|     Credentials.V1 a b
         ^^^^^^^^^^^^^^
The `Credentials` module does not expose a `V1` variant. These names seem close
though:

    Result.Ok
    Basics.EQ
    Basics.False
    Basics.GT

Hint: Read <https://elm-lang.org/0.19.1/imports> to see how `import`
declarations work in Elm.
```

In this case, the `V1` constructor is not exposed in `src/Credentials.elm`, so again it can't be reached for our current prod types.

As soon as your Types.elm changes, you'll have a new set of "current production Types" – and that's when the V2 snapshot types start getting used (and why your migrations are written in terms of them).

Hope that clarifies things!

I will think about whether it's possible to add an additional error message hinting that these errors occurred after the sneaky `Evergreen.V[next].*` -> `*` rewrite in migration checking. 


